### PR TITLE
MO-1638 Show error summary

### DIFF
--- a/server/routes/probationTeams/controller.ts
+++ b/server/routes/probationTeams/controller.ts
@@ -66,7 +66,7 @@ export const deleteProbationTeam: RequestHandlerWithServices =
   }
 
 const validations = [
-  body('emailAddress').isEmail().withMessage('Please enter a valid email address'),
   body('teamCode').notEmpty().withMessage('Please enter a team code'),
+  body('emailAddress').isEmail().withMessage('Please enter a valid email address'),
   body('localDeliveryUnitMailboxId').notEmpty().withMessage('Please select a Local Delivery Unit'),
 ]

--- a/server/views/macros/ldus.njk
+++ b/server/views/macros/ldus.njk
@@ -2,6 +2,6 @@
   {% if ldu.name %}
     {{ ldu.name }}
   {% else %}
-    {{ ldu.email }}
+    {{ ldu.emailAddress }}
   {% endif %}
 {% endmacro %}

--- a/server/views/pages/lduMailboxes/_form.njk
+++ b/server/views/pages/lduMailboxes/_form.njk
@@ -14,10 +14,11 @@
   label: {
     text: "Email Address"
   },
-  id: "email-address",
+  id: "emailAddress",
   name: "emailAddress",
   value: mailbox.emailAddress,
-  errorMessage: validationErrors | errorFor("emailAddress")
+  errorMessage: validationErrors | errorFor("emailAddress"),
+  classes: "govuk-!-width-two-thirds"
 }) }}
 
 {{ govukInput({
@@ -35,7 +36,7 @@
   label: {
     text: "Unit Code"
   },
-  id: "unit-code",
+  id: "unitCode",
   name: "unitCode",
   value: mailbox.unitCode,
   errorMessage: validationErrors | errorFor("unitCode"),
@@ -46,7 +47,7 @@
   label: {
     text: "Area Code"
   },
-  id: "area-code",
+  id: "areaCode",
   name: "areaCode",
   value: mailbox.areaCode,
   errorMessage: validationErrors | errorFor("areaCode"),

--- a/server/views/pages/lduMailboxes/edit.njk
+++ b/server/views/pages/lduMailboxes/edit.njk
@@ -31,6 +31,8 @@
       <form method="post" action="/local-delivery-unit-mailboxes/{{ mailbox.id }}">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
+        {% include 'partials/errorSummary.njk' %}
+
         {% call govukFieldset({
           legend: {
             text: "Edit Local Delivery Unit Mailbox",

--- a/server/views/pages/lduMailboxes/index.njk
+++ b/server/views/pages/lduMailboxes/index.njk
@@ -1,5 +1,6 @@
 {% extends "../../partials/layout.njk" %}
 {%- from "govuk/components/table/macro.njk" import govukTable -%}
+{% import "../../macros/ldus.njk" as ldus %}
 
 {% set pageTitle = applicationName + " - LDU Mailboxes" %}
 {% set mainClasses = "app-container govuk-body" %}
@@ -30,7 +31,7 @@
   {% for mailbox in mailboxes %}
     {% set tableRows = (tableRows.push([
       {
-        html: '<a href="/local-delivery-unit-mailboxes/' + mailbox.id + '/edit" class="govuk-link">' + mailbox.name + '</a>',
+        html: '<a href="/local-delivery-unit-mailboxes/' + mailbox.id + '/edit" class="govuk-link">' + ldus.nameOrEmail(mailbox) + '</a>',
         attributes: {
           "data-qa": "name-column",
           "data-sort-value": mailbox.name

--- a/server/views/pages/lduMailboxes/new.njk
+++ b/server/views/pages/lduMailboxes/new.njk
@@ -34,6 +34,8 @@
       <form method="post" action="/local-delivery-unit-mailboxes">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
+        {% include 'partials/errorSummary.njk' %}
+
         {% call govukFieldset({
           legend: {
             text: "New Local Delivery Unit Mailbox",

--- a/server/views/pages/omuMailboxes/_form.njk
+++ b/server/views/pages/omuMailboxes/_form.njk
@@ -15,7 +15,7 @@
   label: {
     text: "Email Address"
   },
-  id: "email-address",
+  id: "emailAddress",
   name: "emailAddress",
   value: mailbox.emailAddress,
   errorMessage: validationErrors | errorFor("emailAddress"),

--- a/server/views/pages/omuMailboxes/edit.njk
+++ b/server/views/pages/omuMailboxes/edit.njk
@@ -11,40 +11,46 @@
 
 {% block content %}
 
-  {{
-    govukBreadcrumbs({
-      items: [
-        {
-          text: "Home",
-          href: "/"
-        },
-        {
-          text: "Offender Management Unit Mailboxes",
-          href: "/offender-management-unit-mailboxes"
-        },
-        {
-          text: "Edit"
-        }
-      ]
-    }) 
-  }}
-
-  <form method="post" action="/offender-management-unit-mailboxes/{{ mailbox.id }}">
-    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-
-    {% call govukFieldset({
-      legend: {
-        text: "Edit Offender Management Unit Mailbox",
-        classes: "govuk-fieldset__legend--l",
-        isPageHeading: true
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "/"
+      },
+      {
+        text: "Offender Management Unit Mailboxes",
+        href: "/offender-management-unit-mailboxes"
+      },
+      {
+        text: "Edit"
       }
-    }) %}
+    ]
+  }) }}
 
-    {% set isEdit = true %}
-    {% include "pages/omuMailboxes/_form.njk" %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-    {% endcall %}
+      <form method="post" action="/offender-management-unit-mailboxes/{{ mailbox.id }}">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-  </form>
+        {% include 'partials/errorSummary.njk' %}
+
+        {% call govukFieldset({
+          legend: {
+            text: "Edit Offender Management Unit Mailbox",
+            classes: "govuk-fieldset__legend--l",
+            isPageHeading: true
+          }
+        }) %}
+
+        {% set isEdit = true %}
+        {% include "pages/omuMailboxes/_form.njk" %}
+
+        {% endcall %}
+
+      </form>
+
+    </div>
+  </div>
 
 {% endblock %}

--- a/server/views/pages/omuMailboxes/new.njk
+++ b/server/views/pages/omuMailboxes/new.njk
@@ -11,40 +11,46 @@
 
 {% block content %}
 
-  {{
-    govukBreadcrumbs({
-      items: [
-        {
-          text: "Home",
-          href: "/"
-        },
-        {
-          text: "Offender Management Unit Mailboxes",
-          href: "/offender-management-unit-mailboxes"
-        },
-        {
-          text: "New"
-        }
-      ]
-    }) 
-  }}
-
-  <form method="post" action="/offender-management-unit-mailboxes">
-    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-
-    {% call govukFieldset({
-      legend: {
-        text: "New Offender Management Unit Mailbox",
-        classes: "govuk-fieldset__legend--l",
-        isPageHeading: true
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "/"
+      },
+      {
+        text: "Offender Management Unit Mailboxes",
+        href: "/offender-management-unit-mailboxes"
+      },
+      {
+        text: "New"
       }
-    }) %}
+    ]
+  }) }}
 
-    {% set isEdit = false %}
-    {% include "pages/omuMailboxes/_form.njk" %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-    {% endcall %}
+      <form method="post" action="/offender-management-unit-mailboxes">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-  </form>
+        {% include 'partials/errorSummary.njk' %}
+
+        {% call govukFieldset({
+          legend: {
+            text: "New Offender Management Unit Mailbox",
+            classes: "govuk-fieldset__legend--l",
+            isPageHeading: true
+          }
+        }) %}
+
+        {% set isEdit = false %}
+        {% include "pages/omuMailboxes/_form.njk" %}
+
+        {% endcall %}
+
+      </form>
+
+    </div>
+  </div>
 
 {% endblock %}

--- a/server/views/pages/probationTeams/_form.njk
+++ b/server/views/pages/probationTeams/_form.njk
@@ -4,7 +4,7 @@
   label: {
     text: "Team Code"
   },
-  id: "team-code",
+  id: "teamCode",
   name: "teamCode",
   value: probationTeam.teamCode,
   errorMessage: validationErrors | errorFor("teamCode"),
@@ -15,7 +15,7 @@
   label: {
     text: "Email Address"
   },
-  id: "email-address",
+  id: "emailAddress",
   name: "emailAddress",
   value: probationTeam.emailAddress,
   errorMessage: validationErrors | errorFor("emailAddress"),

--- a/server/views/pages/probationTeams/edit.njk
+++ b/server/views/pages/probationTeams/edit.njk
@@ -11,39 +11,45 @@
 
 {% block content %}
 
-  {{
-    govukBreadcrumbs({
-      items: [
-        {
-          text: "Home",
-          href: "/"
-        },
-        {
-          text: "Probation Teams",
-          href: "/probation-teams"
-        },
-        {
-          text: "Edit"
-        }
-      ]
-    }) 
-  }}
-
-  <form method="post" action="/probation-teams/{{ probationTeam.id }}">
-    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-
-    {% call govukFieldset({
-      legend: {
-        text: "Edit Probation Team",
-        classes: "govuk-fieldset__legend--l",
-        isPageHeading: true
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "/"
+      },
+      {
+        text: "Probation Teams",
+        href: "/probation-teams"
+      },
+      {
+        text: "Edit"
       }
-    }) %}
+    ]
+  }) }}
 
-    {% set isEdit = true %}
-    {% include "pages/probationTeams/_form.njk" %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-    {% endcall %}
-  </form>
+      <form method="post" action="/probation-teams/{{ probationTeam.id }}">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+        {% include 'partials/errorSummary.njk' %}
+
+        {% call govukFieldset({
+          legend: {
+            text: "Edit Probation Team",
+            classes: "govuk-fieldset__legend--l",
+            isPageHeading: true
+          }
+        }) %}
+
+        {% set isEdit = true %}
+        {% include "pages/probationTeams/_form.njk" %}
+
+        {% endcall %}
+      </form>
+
+    </div>
+  </div>
 
 {% endblock %}

--- a/server/views/pages/probationTeams/new.njk
+++ b/server/views/pages/probationTeams/new.njk
@@ -11,40 +11,46 @@
 
 {% block content %}
 
-  {{
-    govukBreadcrumbs({
-      items: [
-        {
-          text: "Home",
-          href: "/"
-        },
-        {
-          text: "Probation Teams",
-          href: "/probation-teams"
-        },
-        {
-          text: "New"
-        }
-      ]
-    }) 
-  }}
-
-  <form method="post" action="/probation-teams">
-    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-
-    {% call govukFieldset({
-      legend: {
-        text: "New Probation Team",
-        classes: "govuk-fieldset__legend--l",
-        isPageHeading: true
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Home",
+        href: "/"
+      },
+      {
+        text: "Probation Teams",
+        href: "/probation-teams"
+      },
+      {
+        text: "New"
       }
-    }) %}
+    ]
+  }) }}
 
-    {% set isEdit = false %}
-    {% include "pages/probationTeams/_form.njk" %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-    {% endcall %}
+      <form method="post" action="/probation-teams">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-  </form>
+        {% include 'partials/errorSummary.njk' %}
+
+        {% call govukFieldset({
+          legend: {
+            text: "New Probation Team",
+            classes: "govuk-fieldset__legend--l",
+            isPageHeading: true
+          }
+        }) %}
+
+        {% set isEdit = false %}
+        {% include "pages/probationTeams/_form.njk" %}
+
+        {% endcall %}
+
+      </form>
+
+    </div>
+  </div>
 
 {% endblock %}

--- a/server/views/partials/errorSummary.njk
+++ b/server/views/partials/errorSummary.njk
@@ -1,0 +1,16 @@
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% if validationErrors %}
+  {% set errorList = [] %}
+
+  {% for fieldName, message in validationErrors %}
+    {% set errorItem = { text: message, href: '#' + fieldName } %}
+    {% set errorList = errorList.concat(errorItem) %}
+  {% endfor %}
+
+  {{ govukErrorSummary({
+    titleText: "There is a problem",
+    classes: "govuk-!-margin-top-4",
+    errorList: errorList
+  }) }}
+{% endif %}


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1638

We already show the errors in the individual form elements, but we were missing the error summary at the top of the page to summarise any errors a user has made.

Fix some govuk-grid markup inconsistencies.

![Screenshot 2025-02-19 at 09 41 06](https://github.com/user-attachments/assets/a7e00a32-c9f2-4a30-a38f-dc38e90e42d0)
