### PR TITLE
MO-1671 Tidy up roles

### DIFF
--- a/integration_tests/e2e/lduMailboxes.cy.ts
+++ b/integration_tests/e2e/lduMailboxes.cy.ts
@@ -5,6 +5,20 @@ import EditLduMailboxPage from '../pages/editLduMailbox'
 import DeleteLduMailboxPage from '../pages/deleteLduMailbox'
 import AuthRole from '../../server/data/authRole'
 
+context('Listing LDU mailboxes', () => {
+  beforeEach(() => {
+    cy.task('reset')
+  })
+
+  it('Denies access to user without the PRISON or admin roles', () => {
+    cy.task('stubSignIn', { roles: [] })
+    cy.signIn()
+
+    cy.visit('/local-delivery-unit-mailboxes', { failOnStatusCode: false })
+    cy.url().should('contain', '/access-denied')
+  })
+})
+
 context('Creating an LDU mailbox', () => {
   beforeEach(() => {
     cy.task('reset')
@@ -12,16 +26,16 @@ context('Creating an LDU mailbox', () => {
     cy.task('stubListLduMailboxes')
   })
 
-  it('Denies access to user without the PRISON role', () => {
-    cy.task('stubSignIn', { roles: [] })
+  it('Denies access to user without the MOIC_ADMIN role', () => {
+    cy.task('stubSignIn', { roles: [AuthRole.PRISON] })
     cy.signIn()
 
-    cy.visit('/local-delivery-unit-mailboxes', { failOnStatusCode: false })
+    cy.visit('/local-delivery-unit-mailboxes/new', { failOnStatusCode: false })
     cy.url().should('contain', '/access-denied')
   })
 
   it('Enters the details and submits the form', () => {
-    cy.task('stubSignIn', { roles: [AuthRole.PRISON] })
+    cy.task('stubSignIn', { roles: [AuthRole.MOIC_ADMIN] })
     cy.signIn()
 
     const page = new IndexPage()
@@ -46,7 +60,7 @@ context('Creating an LDU mailbox', () => {
 context('Updating an LDU mailbox', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', { roles: [AuthRole.PRISON] })
+    cy.task('stubSignIn', { roles: [AuthRole.MOIC_ADMIN] })
     cy.task('stubListLduMailboxes')
     cy.task('stubGetLduMailbox')
     cy.task('stubUpdateLduMailbox')
@@ -79,7 +93,7 @@ context('Updating an LDU mailbox', () => {
 context('Deleting an LDU mailbox', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', { roles: [AuthRole.PRISON] })
+    cy.task('stubSignIn', { roles: [AuthRole.MOIC_ADMIN] })
     cy.task('stubListLduMailboxes')
     cy.task('stubGetLduMailbox')
     cy.task('stubDeleteLduMailbox')

--- a/integration_tests/e2e/omuMailboxes.cy.ts
+++ b/integration_tests/e2e/omuMailboxes.cy.ts
@@ -5,6 +5,20 @@ import NewOmuMailboxPage from '../pages/newOmuMailbox'
 import EditOmuMailboxPage from '../pages/editOmuMailbox'
 import DeleteOmuMailboxPage from '../pages/deleteOmuMailbox'
 
+context('Listing OMU mailboxes', () => {
+  beforeEach(() => {
+    cy.task('reset')
+  })
+
+  it('Denies access to user without the PROBATION or admin roles', () => {
+    cy.task('stubSignIn', { roles: [] })
+    cy.signIn()
+
+    cy.visit('/offender-management-unit-mailboxes', { failOnStatusCode: false })
+    cy.url().should('contain', '/access-denied')
+  })
+})
+
 context('Creating an OMU mailbox', () => {
   beforeEach(() => {
     cy.task('reset')
@@ -13,16 +27,16 @@ context('Creating an OMU mailbox', () => {
     cy.task('stubListPrisonCodes')
   })
 
-  it('Denies access to user without the PROBATION role', () => {
-    cy.task('stubSignIn', { roles: [] })
+  it('Denies access to user without the SUPPORT role', () => {
+    cy.task('stubSignIn', { roles: [AuthRole.PROBATION] })
     cy.signIn()
 
-    cy.visit('/offender-management-unit-mailboxes', { failOnStatusCode: false })
+    cy.visit('/offender-management-unit-mailboxes/new', { failOnStatusCode: false })
     cy.url().should('contain', '/access-denied')
   })
 
   it('Enters the details and submits the form', () => {
-    cy.task('stubSignIn', { roles: [AuthRole.PROBATION] })
+    cy.task('stubSignIn', { roles: [AuthRole.SUPPORT] })
     cy.signIn()
 
     const page = new IndexPage()
@@ -47,7 +61,7 @@ context('Creating an OMU mailbox', () => {
 context('Deleting an OMU mailbox', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', { roles: [AuthRole.PROBATION] })
+    cy.task('stubSignIn', { roles: [AuthRole.SUPPORT] })
     cy.task('stubListPrisonCodes')
     cy.task('stubListOmuMailboxes')
     cy.task('stubGetOmuMailbox')

--- a/integration_tests/e2e/probationTeams.cy.ts
+++ b/integration_tests/e2e/probationTeams.cy.ts
@@ -5,6 +5,20 @@ import EditProbationTeamPage from '../pages/editProbationTeam'
 import DeleteProbationTeamPage from '../pages/deleteProbationTeam'
 import NewProbationTeamPage from '../pages/newProbationTeam'
 
+context('Listing probation teams', () => {
+  beforeEach(() => {
+    cy.task('reset')
+  })
+
+  it('Denies access to user without the PRISON or admin roles', () => {
+    cy.task('stubSignIn', { roles: [] })
+    cy.signIn()
+
+    cy.visit('/probation-teams', { failOnStatusCode: false })
+    cy.url().should('contain', '/access-denied')
+  })
+})
+
 context('Creating a probation team', () => {
   beforeEach(() => {
     cy.task('reset')
@@ -13,16 +27,16 @@ context('Creating a probation team', () => {
     cy.task('stubListProbationTeams')
   })
 
-  it('Denies access to user without the PRISON role', () => {
-    cy.task('stubSignIn', { roles: [] })
+  it('Denies access to user without the SUPPORT role', () => {
+    cy.task('stubSignIn', { roles: [AuthRole.PRISON] })
     cy.signIn()
 
-    cy.visit('/probation-teams', { failOnStatusCode: false })
+    cy.visit('/probation-teams/new', { failOnStatusCode: false })
     cy.url().should('contain', '/access-denied')
   })
 
   it('Enters the details and submits the form', () => {
-    cy.task('stubSignIn', { roles: [AuthRole.PRISON] })
+    cy.task('stubSignIn', { roles: [AuthRole.SUPPORT] })
     cy.signIn()
 
     const page = new IndexPage()
@@ -46,7 +60,7 @@ context('Creating a probation team', () => {
 context('Deleting a probation team', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn', { roles: [AuthRole.PRISON] })
+    cy.task('stubSignIn', { roles: [AuthRole.SUPPORT] })
     cy.task('stubListLduMailboxes')
     cy.task('stubListProbationTeams')
     cy.task('stubGetProbationTeam')

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -11,6 +11,7 @@ import AuthRole from '../data/authRole'
 export default (services: Services): Router => {
   const router = Router()
 
+  const adminRoleCheck = roleCheckMiddleware([AuthRole.MOIC_ADMIN, AuthRole.SUPPORT])
   const prisonOrAdminRoleCheck = roleCheckMiddleware([AuthRole.PRISON, AuthRole.MOIC_ADMIN, AuthRole.SUPPORT])
   const probationOrAdminRoleCheck = roleCheckMiddleware([AuthRole.PROBATION, AuthRole.MOIC_ADMIN, AuthRole.SUPPORT])
 
@@ -21,28 +22,28 @@ export default (services: Services): Router => {
   get('/', home.index)
 
   get('/local-delivery-unit-mailboxes', prisonOrAdminRoleCheck, ldus.index(services))
-  get('/local-delivery-unit-mailboxes/new', prisonOrAdminRoleCheck, ldus.newMailbox)
-  post('/local-delivery-unit-mailboxes', prisonOrAdminRoleCheck, ldus.create(services))
-  get('/local-delivery-unit-mailboxes/:id/edit', prisonOrAdminRoleCheck, ldus.edit(services))
-  post('/local-delivery-unit-mailboxes/:id', prisonOrAdminRoleCheck, ldus.update(services))
-  get('/local-delivery-unit-mailboxes/:id/delete', prisonOrAdminRoleCheck, ldus.confirmDelete(services))
-  destroy('/local-delivery-unit-mailboxes/:id', prisonOrAdminRoleCheck, ldus.deleteMailbox(services))
+  get('/local-delivery-unit-mailboxes/new', adminRoleCheck, ldus.newMailbox)
+  post('/local-delivery-unit-mailboxes', adminRoleCheck, ldus.create(services))
+  get('/local-delivery-unit-mailboxes/:id/edit', adminRoleCheck, ldus.edit(services))
+  post('/local-delivery-unit-mailboxes/:id', adminRoleCheck, ldus.update(services))
+  get('/local-delivery-unit-mailboxes/:id/delete', adminRoleCheck, ldus.confirmDelete(services))
+  destroy('/local-delivery-unit-mailboxes/:id', adminRoleCheck, ldus.deleteMailbox(services))
 
   get('/offender-management-unit-mailboxes', probationOrAdminRoleCheck, omus.index(services))
-  get('/offender-management-unit-mailboxes/new', probationOrAdminRoleCheck, omus.newMailbox(services))
-  post('/offender-management-unit-mailboxes', probationOrAdminRoleCheck, omus.create(services))
-  get('/offender-management-unit-mailboxes/:id/edit', probationOrAdminRoleCheck, omus.edit(services))
-  post('/offender-management-unit-mailboxes/:id', probationOrAdminRoleCheck, omus.update(services))
-  get('/offender-management-unit-mailboxes/:id/delete', probationOrAdminRoleCheck, omus.confirmDelete(services))
-  destroy('/offender-management-unit-mailboxes/:id', probationOrAdminRoleCheck, omus.deleteMailbox(services))
+  get('/offender-management-unit-mailboxes/new', adminRoleCheck, omus.newMailbox(services))
+  post('/offender-management-unit-mailboxes', adminRoleCheck, omus.create(services))
+  get('/offender-management-unit-mailboxes/:id/edit', adminRoleCheck, omus.edit(services))
+  post('/offender-management-unit-mailboxes/:id', adminRoleCheck, omus.update(services))
+  get('/offender-management-unit-mailboxes/:id/delete', adminRoleCheck, omus.confirmDelete(services))
+  destroy('/offender-management-unit-mailboxes/:id', adminRoleCheck, omus.deleteMailbox(services))
 
   get('/probation-teams', prisonOrAdminRoleCheck, probationTeams.index(services))
-  get('/probation-teams/new', prisonOrAdminRoleCheck, probationTeams.newProbationTeam(services))
-  post('/probation-teams', prisonOrAdminRoleCheck, probationTeams.create(services))
-  get('/probation-teams/:id/edit', prisonOrAdminRoleCheck, probationTeams.edit(services))
-  post('/probation-teams/:id', prisonOrAdminRoleCheck, probationTeams.update(services))
-  get('/probation-teams/:id/delete', prisonOrAdminRoleCheck, probationTeams.confirmDelete(services))
-  destroy('/probation-teams/:id', prisonOrAdminRoleCheck, probationTeams.deleteProbationTeam(services))
+  get('/probation-teams/new', adminRoleCheck, probationTeams.newProbationTeam(services))
+  post('/probation-teams', adminRoleCheck, probationTeams.create(services))
+  get('/probation-teams/:id/edit', adminRoleCheck, probationTeams.edit(services))
+  post('/probation-teams/:id', adminRoleCheck, probationTeams.update(services))
+  get('/probation-teams/:id/delete', adminRoleCheck, probationTeams.confirmDelete(services))
+  destroy('/probation-teams/:id', adminRoleCheck, probationTeams.deleteProbationTeam(services))
 
   return router
 }

--- a/server/routes/localDeliveryUnitMailboxes/controller.test.ts
+++ b/server/routes/localDeliveryUnitMailboxes/controller.test.ts
@@ -3,6 +3,7 @@ import { testRequestHandler } from '../testutils/requestHandler'
 import { index, create, deleteMailbox, update } from './controller'
 import { ResponseErrorWithData } from '../../services/validation'
 import { LocalDeliveryUnitMailbox } from '../../@types/mailboxRegisterApiClientTypes'
+import AuthRole from '../../data/authRole'
 
 const mailboxRegisterService = {
   listLocalDeliveryUnitMailboxes: jest.fn(),
@@ -36,14 +37,15 @@ const body = {
 
 describe('index', () => {
   it('retrieves a list of mailboxes from the backend', async () => {
-    const [req, res, next] = testRequestHandler({})
+    const [req, res, next] = testRequestHandler({ user: { userRoles: [AuthRole.MOIC_ADMIN] } })
     const mailboxes: LocalDeliveryUnitMailbox[] = []
+    const viewContext = { hasAdminRole: true }
 
     mailboxRegisterService.listLocalDeliveryUnitMailboxes.mockReturnValue(mailboxes)
     await index(services)(req, res, next)
 
     expect(mailboxRegisterService.listLocalDeliveryUnitMailboxes).toHaveBeenCalledWith('CL13NT_T0K3N')
-    expect(res.render).toHaveBeenCalledWith('pages/lduMailboxes/index', { mailboxes })
+    expect(res.render).toHaveBeenCalledWith('pages/lduMailboxes/index', { mailboxes, viewContext })
   })
 })
 

--- a/server/routes/localDeliveryUnitMailboxes/controller.ts
+++ b/server/routes/localDeliveryUnitMailboxes/controller.ts
@@ -2,13 +2,15 @@ import { body, matchedData } from 'express-validator'
 import { RequestHandler, RequestHandlerWithServices } from '../../services'
 import { validatedRequest } from '../../services/validation'
 import { clientToken } from '../clientToken'
+import { hasAdminRole } from '../../utils/utils'
 
 export const index: RequestHandlerWithServices =
   ({ mailboxRegisterService }) =>
   async (req, res, next) => {
     const mailboxes = await mailboxRegisterService.listLocalDeliveryUnitMailboxes(clientToken(req))
+    const viewContext = { hasAdminRole: hasAdminRole(req.user) }
 
-    res.render('pages/lduMailboxes/index', { mailboxes })
+    res.render('pages/lduMailboxes/index', { mailboxes, viewContext })
   }
 
 export const create: RequestHandlerWithServices = ({ mailboxRegisterService }) =>

--- a/server/routes/offenderManagementUnitMailboxes/controller.test.ts
+++ b/server/routes/offenderManagementUnitMailboxes/controller.test.ts
@@ -3,6 +3,7 @@ import { index, create, deleteMailbox, update } from './controller'
 import { testRequestHandler } from '../testutils/requestHandler'
 import { ResponseErrorWithData } from '../../services/validation'
 import { OffenderManagementUnitMailbox } from '../../@types/mailboxRegisterApiClientTypes'
+import AuthRole from '../../data/authRole'
 
 const body = {
   name: 'A Name',
@@ -38,16 +39,17 @@ const sharedValidationRules = [
 
 describe('index', () => {
   it('retrieves a list of mailboxes from the backend', async () => {
-    const [req, res, next] = testRequestHandler({})
+    const [req, res, next] = testRequestHandler({ user: { userRoles: [AuthRole.SUPPORT] } })
     const mailboxes: OffenderManagementUnitMailbox[] = []
     const prisons = [{ LEI: 'Leeds' }, { WHI: 'Woodhill' }]
+    const viewContext = { hasAdminRole: true }
 
     mailboxRegisterService.listPrisonCodes.mockReturnValue({ prisons })
     mailboxRegisterService.listOffenderManagementUnitMailboxes.mockReturnValue(mailboxes)
     await index(services)(req, res, next)
 
     expect(mailboxRegisterService.listOffenderManagementUnitMailboxes).toHaveBeenCalledWith('CL13NT_T0K3N')
-    expect(res.render).toHaveBeenCalledWith('pages/omuMailboxes/index', { mailboxes, prisons })
+    expect(res.render).toHaveBeenCalledWith('pages/omuMailboxes/index', { mailboxes, prisons, viewContext })
   })
 })
 

--- a/server/routes/offenderManagementUnitMailboxes/controller.ts
+++ b/server/routes/offenderManagementUnitMailboxes/controller.ts
@@ -3,13 +3,16 @@ import { RequestHandlerWithServices } from '../../services'
 import { prisonCodeOptions } from './prisons'
 import { validatedRequest } from '../../services/validation'
 import { clientToken } from '../clientToken'
+import { hasAdminRole } from '../../utils/utils'
 
 export const index: RequestHandlerWithServices =
   ({ mailboxRegisterService }) =>
   async (req, res, next) => {
     const mailboxes = await mailboxRegisterService.listOffenderManagementUnitMailboxes(clientToken(req))
     const { prisons } = await mailboxRegisterService.listPrisonCodes(clientToken(req))
-    res.render('pages/omuMailboxes/index', { mailboxes, prisons })
+    const viewContext = { hasAdminRole: hasAdminRole(req.user) }
+
+    res.render('pages/omuMailboxes/index', { mailboxes, prisons, viewContext })
   }
 
 export const newMailbox: RequestHandlerWithServices =

--- a/server/routes/probationTeams/controller.test.ts
+++ b/server/routes/probationTeams/controller.test.ts
@@ -2,6 +2,7 @@ import { Services } from '../../services'
 import { ResponseErrorWithData } from '../../services/validation'
 import { testRequestHandler } from '../testutils/requestHandler'
 import { create, edit, index, newProbationTeam, update, deleteProbationTeam } from './controller'
+import AuthRole from '../../data/authRole'
 
 const mailboxRegisterService = {
   createProbationTeam: jest.fn(),
@@ -81,10 +82,12 @@ describe('index', () => {
       { id: 123, emailAddress: 'probation.team1@email.com' },
       { id: 456, emailAddress: 'probation.team2@email.com' },
     ]
+    const viewContext = { hasAdminRole: true }
     mailboxRegisterService.listProbationTeams.mockReturnValue(probationTeams)
-    const [req, res, next] = testRequestHandler({})
+    const [req, res, next] = testRequestHandler({ user: { userRoles: [AuthRole.MOIC_ADMIN] } })
+
     await index(services)(req, res, next)
-    expect(res.render).toHaveBeenCalledWith('pages/probationTeams/index', { probationTeams })
+    expect(res.render).toHaveBeenCalledWith('pages/probationTeams/index', { probationTeams, viewContext })
   })
 })
 

--- a/server/routes/probationTeams/controller.ts
+++ b/server/routes/probationTeams/controller.ts
@@ -2,6 +2,7 @@ import { body, matchedData } from 'express-validator'
 import { RequestHandlerWithServices } from '../../services'
 import { validatedRequest } from '../../services/validation'
 import { clientToken } from '../clientToken'
+import { hasAdminRole } from '../../utils/utils'
 
 export const newProbationTeam: RequestHandlerWithServices =
   ({ mailboxRegisterService }) =>
@@ -30,7 +31,9 @@ export const index: RequestHandlerWithServices =
   ({ mailboxRegisterService }) =>
   async (req, res) => {
     const probationTeams = await mailboxRegisterService.listProbationTeams(clientToken(req))
-    res.render('pages/probationTeams/index', { probationTeams })
+    const viewContext = { hasAdminRole: hasAdminRole(req.user) }
+
+    res.render('pages/probationTeams/index', { probationTeams, viewContext })
   }
 
 export const create: RequestHandlerWithServices = ({ mailboxRegisterService }) =>

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -34,7 +34,8 @@ const errorForField = (errors: { [field: string]: string }, fieldName: string) =
 }
 
 const hasRole = (user: Express.User, role: AuthRole): boolean => user?.userRoles.includes(role) || false
-const hasRoleOrAdmin = (user: Express.User, role: AuthRole): boolean =>
-  hasRole(user, role) || hasRole(user, AuthRole.MOIC_ADMIN) || hasRole(user, AuthRole.SUPPORT)
+const hasRoleOrAdmin = (user: Express.User, role: AuthRole): boolean => hasRole(user, role) || hasAdminRole(user)
+const hasAdminRole = (user: Express.User): boolean =>
+  hasRole(user, AuthRole.MOIC_ADMIN) || hasRole(user, AuthRole.SUPPORT)
 
-export { hasRoleOrAdmin, properCase, convertToTitleCase, initialiseName, formatDate, errorForField }
+export { hasAdminRole, hasRoleOrAdmin, properCase, convertToTitleCase, initialiseName, formatDate, errorForField }

--- a/server/views/pages/lduMailboxes/index.njk
+++ b/server/views/pages/lduMailboxes/index.njk
@@ -22,10 +22,12 @@
   }}
 
   <h1 class="govuk-heading-l">Local Delivery Unit Mailboxes</h1>
-  
+
+  {% if viewContext.hasAdminRole %}
   <p class="govuk-body">
     <a href="/local-delivery-unit-mailboxes/new" class="govuk-link govuk-link--no-visited-state">Create new Local Delivery Unit Mailbox</a>
   </p>
+  {% endif %}
 
   {% set tableRows = [] %}
   {% for mailbox in mailboxes %}
@@ -53,6 +55,7 @@
     ]), tableRows) %}
   {% endfor %}
 
+  {% if mailboxes.length %}
   {{ govukTable({
     attributes: {
       'data-module': 'moj-sortable-table'
@@ -85,5 +88,8 @@
     ],
     rows: tableRows
   }) }}
+  {% else %}
+    <p class="govuk-body">No Local Delivery Unit Mailboxes have been created yet.</p>
+  {% endif %}
 
 {% endblock %}

--- a/server/views/pages/omuMailboxes/index.njk
+++ b/server/views/pages/omuMailboxes/index.njk
@@ -20,10 +20,12 @@
 
   <h1 class="govuk-heading-l">Offender Management Unit Mailboxes</h1>
 
+  {% if viewContext.hasAdminRole %}
   <p class="govuk-body">
     <a href="/offender-management-unit-mailboxes/new" class="govuk-link govuk-link--no-visited-state">Create new
       Offender Management Unit Mailbox</a>
   </p>
+  {% endif %}
 
   {% set tableRows = [] %}
   {% for mailbox in mailboxes %}
@@ -53,6 +55,7 @@
     ]), tableRows) %}
   {% endfor %}
 
+  {% if mailboxes.length %}
   {{ govukTable({
     attributes: {
       'data-module': 'moj-sortable-table'
@@ -85,5 +88,8 @@
     ],
     rows: tableRows
   }) }}
+  {% else %}
+    <p class="govuk-body">No Offender Management Unit Mailboxes have been created yet.</p>
+  {% endif %}
 
 {% endblock %}

--- a/server/views/pages/probationTeams/index.njk
+++ b/server/views/pages/probationTeams/index.njk
@@ -21,10 +21,12 @@
 
   <h1 class="govuk-heading-l">Probation Teams</h1>
 
+  {% if viewContext.hasAdminRole %}
   <p class="govuk-body">
     <a href="/probation-teams/new" class="govuk-link govuk-link--no-visited-state">Create a new
       Probation Team</a>
   </p>
+  {% endif %}
 
   {% set tableRows = [] %}
   {% for probationTeam in probationTeams %}
@@ -51,6 +53,7 @@
     ]), tableRows) %}
   {% endfor %}
 
+  {% if probationTeams.length %}
   {{
     govukTable({
       attributes: {
@@ -79,5 +82,8 @@
       rows: tableRows
     })
   }}
+  {% else %}
+    <p class="govuk-body">No Probation Teams have been created yet.</p>
+  {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/MO-1671

Only admin roles will have full access (read/write) while PRISON and PROBATION roles will only have read access (i.e. will be able to access the service, and list mailboxes, but nothing else for now).

There are 2 roles considered "admin": `MOIC_ADMIN` and `NOMIS_BATCHLOAD`.